### PR TITLE
Add assert async error example

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,13 @@ import PackageDescription
 
 let package = Package(
     name: "examples-of-swifty-test-assertions",
+    platforms: [
+        .iOS(.v14),
+        .macOS(.v12),
+        .watchOS(.v7),
+        .tvOS(.v15),
+        .visionOS(.v1),
+    ],
     products: [
         .library(
             name: "ExamplesOfSwiftyTestAssertions",
@@ -11,7 +18,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "git@github.com:artem-y/swifty-test-assertions.git", from: "0.1.0"),
+        .package(url: "git@github.com:artem-y/swifty-test-assertions.git", from: "0.1.1"),
     ],
     targets: [
         .target(

--- a/Sources/ExamplesOfSwiftyTestAssertions/Testables.swift
+++ b/Sources/ExamplesOfSwiftyTestAssertions/Testables.swift
@@ -22,4 +22,15 @@ extension Array {
         guard indices.contains(index) else { throw Error.indexOutOfRange }
         return remove(at: index)
     }
+
+    /// Async version of `removeElement`, safely removes an element from the array after delay.
+    /// - parameter index: Index of element to remove.
+    /// - parameter nanoseconds: Delay in nanoseconds to wait before removal.
+    /// - returns: Removed element.
+    /// - throws: Index out of range error, when given index is out of bounds of the array.
+    mutating func removeElement(at index: Int, afterDelay nanoseconds: UInt64 = 0) async throws -> Element {
+        try await Task.sleep(nanoseconds: nanoseconds)
+        guard indices.contains(index) else { throw Error.indexOutOfRange }
+        return remove(at: index)
+    }
 }

--- a/Tests/ExampleTests/Examples.swift
+++ b/Tests/ExampleTests/Examples.swift
@@ -28,4 +28,16 @@ final class Examples: XCTestCase {
             throwsError: Array<Int>.Error.indexOutOfRange // Then
         )
     }
+
+    // MARK: - AssertAsync throwsError
+
+    func test_removeElementAfterDelay_atIndexOutOfBounds_throwsIndexOutOfRangeError() async {
+        // Given
+        var sut = [1, 2, 3, 4, 5, 6]
+
+        await AssertAsync(
+            try await sut.removeElement(at: 6, afterDelay: 100), // When
+            throwsError: Array<Int>.Error.indexOutOfRange // Then
+        )
+    }
 }


### PR DESCRIPTION
In this PR:
- bumped version of [swifty-test-assertions](https://github.com/artem-y/swifty-test-assertions) to `0.1.1`
- specified platforms in Package.swift to enable Swift concurrency
- added test example for `AssertAsync ... throwsError` assertion